### PR TITLE
Add normal version of ratio

### DIFF
--- a/colorcube.js
+++ b/colorcube.js
@@ -1,6 +1,7 @@
 const WHITE  = tinycolor("#ffffff");
 const BLACK  = tinycolor("#000000");
 const LARGETEXTAARATIO = 3;
+const NORMALTEXTAARATIO = 4.5;
 var colorArray = [];
 
 function getRoundedRatio(color1, color2) {
@@ -9,20 +10,26 @@ function getRoundedRatio(color1, color2) {
   return ratio;
 }
 
-function outputRatio(ratio, div) {
-  if ( ratio >= (LARGETEXTAARATIO + 0.5) ) {
-    // if it passes by more than .5, create a green div
-    ratioGreen = '<div class="color-ratios--swatch pass">' + ratio + '</div>';
+function outputRatio(ratio, ratioSize, div) {
+  // change modifier class based on which ratio we're checking against
+  if ( ratioSize == 3 ) {
+    var modifier = '__large';
+  } else {
+    var modifier = '__normal';
+  }
+  if ( ratio >= (ratioSize + 0.5) ) {
+    // if it passes by more than .5, create a div with .pass
+    ratioGreen = '<div class="color-ratios--swatch' + modifier +  ' pass">Pass ' + ratio + '</div>';
     // and append it
     div.innerHTML = div.innerHTML + ratioGreen;
-  } else if ( ratio <= (LARGETEXTAARATIO + 0.5) && ratio >= LARGETEXTAARATIO ) {
-    // if it barely passes, create a yellow div
-    ratioYellow = '<div class="color-ratios--swatch edge">' + ratio + '</div>';
+  } else if ( ratio < (ratioSize + 0.5) && ratio >= ratioSize ) {
+    // if it barely passes, create a div with .edge
+    ratioYellow = '<div class="color-ratios--swatch' + modifier +  ' edge">Edge ' + ratio + '</div>';
     // and append it
     div.innerHTML = div.innerHTML + ratioYellow;
   } else {
-    // if it fails by more than .5, create a red div
-    ratioRed = '<div class="color-ratios--swatch fail">' + ratio + '</div>';
+    // if it fails by more than .5, create a div with .fail
+    ratioRed = '<div class="color-ratios--swatch' + modifier +  ' fail">Fail ' + ratio + '</div>';
     // and append it
     div.innerHTML = div.innerHTML + ratioRed;
   }
@@ -68,12 +75,14 @@ button.onclick = function(e) {
     // get the color's contrast ratio compared to white
     var ratio = getRoundedRatio(colorArray[i], WHITE);
     // 2) output a div with that color's ratio on white
-    outputRatio(ratio, column2);
+    outputRatio(ratio, NORMALTEXTAARATIO, column2);
+    outputRatio(ratio, LARGETEXTAARATIO, column2);
     
     // get the color's contrast ratio compared to black
     var ratio = getRoundedRatio(colorArray[i], BLACK);
     // 3) output a div with that color's ratio on black
-    outputRatio(ratio, column3);
+    outputRatio(ratio, NORMALTEXTAARATIO, column3);
+    outputRatio(ratio, LARGETEXTAARATIO, column3);
     
     // what's most readable with the current color?
     var bestPick = tinycolor.mostReadable(colorArray[i], colorArray);
@@ -84,7 +93,8 @@ button.onclick = function(e) {
     column4.innerHTML = column4.innerHTML + '<div class="color-ratios--swatch most-legible" style="background-color: ' + colorArray[i] + '; color: ' + bestPick['_originalInput'] + '">' + bestPick['_originalInput'] + '</div>';
     // 4) from among colors provided, output a div with
     //    the ratio between those two colors
-    outputRatio(ratio, column4);
+    outputRatio(ratio, NORMALTEXTAARATIO, column4);
+    outputRatio(ratio, LARGETEXTAARATIO, column4);
   }
   // jump to the results
   window.location.href = '#results-content';

--- a/colorcube.js
+++ b/colorcube.js
@@ -1,6 +1,6 @@
 const WHITE  = tinycolor("#ffffff");
 const BLACK  = tinycolor("#000000");
-const AARATIO = 4.5;
+const LARGETEXTAARATIO = 3.1;
 var colorArray = [];
 
 function getRoundedRatio(color1, color2) {
@@ -10,12 +10,12 @@ function getRoundedRatio(color1, color2) {
 }
 
 function outputRatio(ratio, div) {
-  if ( ratio > (AARATIO + 0.5) ) {
+  if ( ratio > (LARGETEXTAARATIO + 0.5) ) {
     // if it passes by more than .5, create a green div
     ratioGreen = '<div class="color-ratios--swatch pass">' + ratio + '</div>';
     // and append it
     div.innerHTML = div.innerHTML + ratioGreen;
-  } else if ( ratio < (AARATIO + 0.5) && ratio > AARATIO ) {
+  } else if ( ratio < (LARGETEXTAARATIO + 0.5) && ratio > LARGETEXTAARATIO ) {
     // if it barely passes, create a yellow div
     ratioYellow = '<div class="color-ratios--swatch edge">' + ratio + '</div>';
     // and append it

--- a/colorcube.js
+++ b/colorcube.js
@@ -1,6 +1,6 @@
 const WHITE  = tinycolor("#ffffff");
 const BLACK  = tinycolor("#000000");
-const LARGETEXTAARATIO = 3.1;
+const LARGETEXTAARATIO = 3;
 var colorArray = [];
 
 function getRoundedRatio(color1, color2) {
@@ -10,12 +10,12 @@ function getRoundedRatio(color1, color2) {
 }
 
 function outputRatio(ratio, div) {
-  if ( ratio > (LARGETEXTAARATIO + 0.5) ) {
+  if ( ratio >= (LARGETEXTAARATIO + 0.5) ) {
     // if it passes by more than .5, create a green div
     ratioGreen = '<div class="color-ratios--swatch pass">' + ratio + '</div>';
     // and append it
     div.innerHTML = div.innerHTML + ratioGreen;
-  } else if ( ratio < (LARGETEXTAARATIO + 0.5) && ratio > LARGETEXTAARATIO ) {
+  } else if ( ratio <= (LARGETEXTAARATIO + 0.5) && ratio >= LARGETEXTAARATIO ) {
     // if it barely passes, create a yellow div
     ratioYellow = '<div class="color-ratios--swatch edge">' + ratio + '</div>';
     // and append it

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -857,7 +857,7 @@ input[type="search"] {
   .color-ratios--column {
     float: left;
     width: 25%; }
-  .color-ratios--swatch {
+  .color-ratios--swatch, .color-ratios--swatch__normal, .color-ratios--swatch__large {
     border: 2px solid black;
     color: white;
     font-size: 24px;
@@ -866,7 +866,7 @@ input[type="search"] {
     margin-bottom: 10px;
     text-align: center;
     width: 60px; }
-    .color-ratios--swatch.most-legible {
+    .color-ratios--swatch.most-legible, .color-ratios--swatch__normal.most-legible, .color-ratios--swatch__large.most-legible {
       float: left;
       font-weight: 700;
       margin-right: 10px;

--- a/src/scss/component/_colorcube.scss
+++ b/src/scss/component/_colorcube.scss
@@ -20,7 +20,9 @@
   }
 
   /* Individual Color Swatches */
-  &--swatch {
+  &--swatch,
+  &--swatch__normal,
+  &--swatch__large, {
     border: 2px solid black;
     color: white;
     font-size: 24px;


### PR DESCRIPTION
### Summary
We were previously only evaluating if the color was passing a ratio of 4.5:1. First, the logic had some flaws in its comparisons. Second, since our font is 24px, that ratio should have been 3:1. Third, this adds the second ratio and outputs those results alongside the others.
### Risk
Medium