### PR TITLE
Hide results block on load, make visible on button click

### DIFF
--- a/colorcube.js
+++ b/colorcube.js
@@ -57,13 +57,11 @@ var colorArray = [];
   }
 })();
 
-
 function getRoundedRatio(color1, color2) {
   var ratio = tinycolor.readability(color1, color2);
   ratio = Math.round(ratio * 10) / 10;
   return ratio;
 }
-
 
 function outputRatio(color, ratio, base, target) {
   var passfail = 'fail',
@@ -96,6 +94,7 @@ var button = document.querySelector('#brand-color--button');
 button.onclick = function(e) {
   e.preventDefault();
 
+  var resultsBlock = document.getElementById('results-content');
   var results = document.getElementById('results-output');
 
   // if there are already results displayed, clear them
@@ -147,6 +146,10 @@ button.onclick = function(e) {
         outputRatio(most_legible, ratio_mostlegible, colorArray[i], AALARGERATIO) + 
       '</div>';
   }
+  
+  // make the results content visible
+  resultsBlock.style.display = 'block';
+  resultsBlock.style.visibility = 'visible';
 
   // jump to the results
   window.location.href = '#results-content';

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -832,6 +832,10 @@ input[type="number"] {
     border: 1px solid #ccc;
     height: 2rem; }
 
+#results-content {
+  display: none;
+  visibility: hidden; }
+
 .results__row {
   display: -webkit-box;
   display: -moz-box;

--- a/src/scss/component/_colorcube.scss
+++ b/src/scss/component/_colorcube.scss
@@ -44,6 +44,10 @@
   }
 }
 
+#results-content {
+  @include hide();
+}
+
 .results {
   
   &__row {


### PR DESCRIPTION
Hides the "Step 2" heading and following copy until there are color results displayed.
Addresses enhancement in https://github.com/oomphinc/colorcube/issues/15.